### PR TITLE
fix: allow deletion of diaries w/out transcripts

### DIFF
--- a/src/services/adminMaintenance/actions/removeDiary.js
+++ b/src/services/adminMaintenance/actions/removeDiary.js
@@ -39,11 +39,13 @@ const runner = async (app, data) => {
   if (data.actuallyDelete) {
     try {
       const destination = app.get('uploads');
-      for (const relatedTranscriptSentence of relatedTranscriptSentences.data) {
-        TranscriptSentenceService.remove(relatedTranscriptSentence.id);
-      }
-      for (const relatedTranscription of relatedTranscriptions.data) {
-        TranscriptionService.remove(relatedTranscription.id);
+      if (relatedTranscriptionCount > 0) {
+        for (const relatedTranscriptSentence of relatedTranscriptSentences.data) {
+          TranscriptSentenceService.remove(relatedTranscriptSentence.id);
+        }
+        for (const relatedTranscription of relatedTranscriptions.data) {
+          TranscriptionService.remove(relatedTranscription.id);
+        }
       }
       for (const relatedDocument of relatedDocuments.data) {
         DocumentService.remove(relatedDocument.id);


### PR DESCRIPTION
Just checks to see if there are transcripts before iterating over them during diary deletion, allowing for diaries without transcriptions to be deleted without throwing an iterator error.

After some local branch finagling, I think this should work for just committing the single change.