### PR TITLE
Fix: filter and search use part. category properly

### DIFF
--- a/src/services/reporting/reports/contentSearch.js
+++ b/src/services/reporting/reports/contentSearch.js
@@ -83,8 +83,8 @@ const reportOutput = async (app, { searchString, params: dataParams}, params) =>
   if (dataParams.categoryFilter && Array.isArray(dataParams.categoryFilter) && dataParams.categoryFilter.length > 0) {
     const categoryFilter = dataParams.categoryFilter
       .map(category => {
-        const participant_category = category.toLowerCase();
-        return `LOWER(subjects.metadata ->> '$.participant_category') = '${participant_category}'`;
+        const participant_category = category;
+        return `JSON_CONTAINS(subjects.metadata, '"${participant_category}"', '$.participant_category')`;
       })
       .join(' OR ');
     queryWhere.push(`(${categoryFilter})`);

--- a/src/services/reporting/reports/diaryFilterer.js
+++ b/src/services/reporting/reports/diaryFilterer.js
@@ -53,8 +53,8 @@ const reportOutput = async (app, { params: dataParams }, params) => {
   if (dataParams.categoryFilter && Array.isArray(dataParams.categoryFilter) && dataParams.categoryFilter.length > 0) {
     const categoryFilter = dataParams.categoryFilter
       .map(category => {
-        const age_category = category.toLowerCase();
-        return `LOWER(subjects.metadata ->> '$.age_category') = '${age_category}'`;
+        const participant_category = category;
+        return `JSON_CONTAINS(subjects.metadata, '"${participant_category}"', '$.participant_category')`;
       })
       .join(' OR ');
     queryWhere.push(`(${categoryFilter})`);


### PR DESCRIPTION
Diary filterer was using age_category and both were checking single strings rather than if the metadata contained the search value