### PR TITLE
Feat: Add first name and email to duration summary

### DIFF
--- a/src/services/reporting/reports/durationSummary.js
+++ b/src/services/reporting/reports/durationSummary.js
@@ -31,6 +31,8 @@ const reportOutput = async (app, { date1, date2, params: dataParams}, params) =>
   */
   let rawq = `select
       subjects.shortcode as 'subjectId', 
+      subjects.first as 'Name',
+      subjects.email as 'Email',
       count(diaries.id) as 'diaryCount',
       sum(diaries.metadata->>"$.duration") / 60 as 'diaryLengthTotal',
       ANY_VALUE(subjects.metadata) as subjectMetadata,


### PR DESCRIPTION
I don't know what happened to line 56/58, but otherwise just adds additional columns to mysql query